### PR TITLE
Update travis to support correct Node.js version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "0.11"
+  - "0.12"


### PR DESCRIPTION
Fly now support Node >= 0.11
